### PR TITLE
chore(main/germanium): set maintainer to @termux

### DIFF
--- a/packages/germanium/build.sh
+++ b/packages/germanium/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/matsuyoshi30/germanium
 TERMUX_PKG_DESCRIPTION="Generate image from source code"
 TERMUX_PKG_LICENSE="MIT"
-TERMUX_PKG_MAINTAINER="Raven Ravener <ravener.anime@gmail.com>"
+TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.2.3"
 TERMUX_PKG_SRCURL=https://github.com/matsuyoshi30/germanium/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=69c818f06bbd7ea562afb5ed38b24fc2e9e9a447d5668d995314da5203e72de3


### PR DESCRIPTION
I simply added the package, I think it's not fair for me to hold the maintainer name as I don't do much and probably can't if something were to happen.